### PR TITLE
Add GitHub Skills activity (Fix for Issue #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,12 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",


### PR DESCRIPTION
## Description
This PR adds the GitHub Skills activity to the extracurricular activities list as mentioned in Issue #6.

## Changes Made
- Added the GitHub Skills activity to the activities dictionary in app.py
- Set up the activity with description, schedule, maximum participants, and an empty participants list
- Placed it at the top of the list for visibility

## Related Issue
Fixes #6

## Testing
- The activity is now visible in the activities list
- Students can sign up for the GitHub Skills activity through the website

This is a time-sensitive fix as registrations for this activity close by the end of the week.